### PR TITLE
chore: Reintroduce Python 3.11 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,7 +39,7 @@ jobs:
       - lint
     strategy:
       matrix:
-        python: [ "3.12", "3.13" ]
+        python: [ "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     name: "Test on Python ${{ matrix.python }}"

--- a/fastapi_cache/coder.py
+++ b/fastapi_cache/coder.py
@@ -29,7 +29,7 @@ CONVERTERS: dict[str, Callable[[Any], Any]] = {
 }
 
 
-def dec_hook[T](type_: type[T], obj: Any) -> T:
+def dec_hook(type_: type[T], obj: Any) -> T:
     if is_subclass_safe(type_, BaseModel):
         if isinstance(obj, bytes):
             return type_.model_validate_json(obj)  # type: ignore[no-any-return, attr-defined]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "long2ice", email = "long2ice@gmail.com" },
     { name = "Yolley", email = "comingreal@gmail.com" },
 ]
-requires-python = "~=3.12"
+requires-python = ">=3.11"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = [
@@ -87,7 +87,7 @@ build-backend = "hatchling.build"
 
 [tool.mypy]
 files = ["."]
-python_version = "3.12"
+python_version = "3.11"
 # equivalent of --strict
 warn_unused_configs = true
 disallow_any_generics = true
@@ -110,14 +110,14 @@ ignore_errors = true
 
 [tool.pyright]
 strict = ["fastapi_cache", "tests"]
-pythonVersion = "3.12"
+pythonVersion = "3.11"
 
 [tool.pytest.ini_options]
 addopts = "-p no:warnings"
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 env_list =
-    py312,py313
+    py311,py312,py313
 minversion = 4.11.3
 
 [gh-actions]
 # Map Github Actions Python version to environment factors
 # Requires tox-gh-actions 3.x is installed in the GitHub action
 python =
+    3.11: py311
     3.12: py312
     3.13: py313
 


### PR DESCRIPTION
Hello @Yolley, first of all thank you for forking and creating this package. My team is currently looking for a package that supports dynamic TTL calculation and distributed locking and `fastapi-cache2-fork` satisfies these needs. Unfortunately, some of our services are still on py3.11.

I took a quick look and the code changes to bring back py3.11 support should be minimal, e.g. `dec_hook[T] → dec_hook` which uses the TypeVar that's still available in the `coder.py` module. The rest I could found would just be config changes (`pyproject.toml`, `tox.ini`, `CI matrix`).

May I ask if you'd be open to a PR to restore Python 3.11 support? Thanks in any case!
